### PR TITLE
Fix for using logger in Xbmq::create()

### DIFF
--- a/lib/xbmq.js
+++ b/lib/xbmq.js
@@ -39,7 +39,7 @@ class Xbmq {
     }).then((ni) => {
       ni = ni.trim()
       if (!ni || ni.length === 0) {
-        this.log('error', 'Local XBEE NI not set.')
+        logger('error', 'Local XBEE NI not set.')
         ni = 'UNKNOWN'
       }
       mqttConfig.topic += '/' + ni


### PR DESCRIPTION
In case NI is not set, Xbmq::create() calls this.log(), which is not yet defined.

```this.log is not a function```